### PR TITLE
TPS control for Test Cases

### DIFF
--- a/components/processor/processor.go
+++ b/components/processor/processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 )
 
 type ContentType uint8
@@ -21,6 +22,8 @@ type Message struct {
 	Type 	 ContentType `json:"type"`
 }
 
+var rateLimiter = time.Tick(5 * time.Millisecond)
+
 func echoString(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "a")
 }
@@ -36,6 +39,8 @@ func parseMessage(w http.ResponseWriter, r *http.Request) {
 
 	log.Println(r.Body)
 	log.Println(m)
+
+	<-rateLimiter
 
 	fmt.Fprintf(w, "OK")
 }

--- a/components/runner/runner.go
+++ b/components/runner/runner.go
@@ -145,7 +145,6 @@ func request(message *Message) {
 }
 
 func main() {
-    // Start a background process that checks the threshold every 30 seconds and dumps a heap profile if necessary
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 


### PR DESCRIPTION
Adds TPS control for running test cases.

A hardcoded list of TPS `tpsAtIteration = []int{10, 20, 50, 100}` is defined at the runner.

Then, the loaded test case runs one time at the given TPS.
